### PR TITLE
add warning to result access methods, fixes #92

### DIFF
--- a/src/main/java/org/opentosca/csarrepo/service/AbstractService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/AbstractService.java
@@ -3,7 +3,12 @@ package org.opentosca.csarrepo.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public abstract class AbstractService {
+
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	private long userId;
 	private List<String> errors;
@@ -41,5 +46,12 @@ public abstract class AbstractService {
 	 */
 	public List<String> getErrors() {
 		return this.errors;
+	}
+
+	protected void logInvalidResultAccess(String methodName) {
+		if (this.hasErrors()) {
+			LOGGER.warn(this.getClass().getName() + "@" + methodName
+					+ ": result accessed despite errors");
+		}
 	}
 }

--- a/src/main/java/org/opentosca/csarrepo/service/DeleteCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/DeleteCsarFileService.java
@@ -35,7 +35,9 @@ public class DeleteCsarFileService extends AbstractService {
 	 * @return status of deletion
 	 */
 	public boolean getResult() {
-		return returnValue;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.returnValue;
 	}
 
 }

--- a/src/main/java/org/opentosca/csarrepo/service/DeleteCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/DeleteCsarService.java
@@ -39,7 +39,9 @@ public class DeleteCsarService extends AbstractService {
 	 * @return status of deletion
 	 */
 	public boolean getResult() {
-		return returnValue;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.returnValue;
 	}
 
 }

--- a/src/main/java/org/opentosca/csarrepo/service/DownloadCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/DownloadCsarService.java
@@ -50,6 +50,8 @@ public class DownloadCsarService extends AbstractService {
 	 * @return File object which holds the CSAR
 	 */
 	public File getResult() {
-		return csarFile;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.csarFile;
 	}
 }

--- a/src/main/java/org/opentosca/csarrepo/service/ListCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/ListCsarFileService.java
@@ -28,7 +28,9 @@ public class ListCsarFileService extends AbstractService {
 	 * @return List of CSARs
 	 */
 	public List<CsarFile> getResult() {
-		return csarFiles;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.csarFiles;
 	}
 
 }

--- a/src/main/java/org/opentosca/csarrepo/service/ListCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/ListCsarService.java
@@ -29,7 +29,9 @@ public class ListCsarService extends AbstractService {
 	 * @return List of CSARs
 	 */
 	public List<Csar> getResult() {
-		return csarFiles;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.csarFiles;
 	}
 
 }

--- a/src/main/java/org/opentosca/csarrepo/service/ShowCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/ShowCsarService.java
@@ -30,6 +30,8 @@ public class ShowCsarService extends AbstractService {
 	 * @return List of CSARs
 	 */
 	public Csar getResult() {
-		return csar;
+		super.logInvalidResultAccess("getResult");
+		
+		return this.csar;
 	}
 }

--- a/src/main/java/org/opentosca/csarrepo/service/UploadCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/UploadCsarService.java
@@ -91,6 +91,8 @@ public class UploadCsarService extends AbstractService {
 	}
 
 	public boolean getResult() {
+		super.logInvalidResultAccess("getResult");
+		
 		return !this.hasErrors();
 	}
 


### PR DESCRIPTION
- added method for logging to abstractClass
- added call to this method in every result access method of a service
