### PR TITLE
temporary fix for the fileSystem refs #143

### DIFF
--- a/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
@@ -60,9 +60,11 @@ public class UploadCsarFileService extends AbstractService {
 				UUID randomFileName = UUID.randomUUID();
 
 				hashedFile = new HashedFile();
-				String fileName = fs.saveToFileSystem(randomFileName, tmpFile);
+				// TODO: #143 ensure that the return is handled or remove the
+				// return alltogether
+				fs.saveToFileSystem(randomFileName, tmpFile);
 				hashedFile.setHash(hash);
-				hashedFile.setFileName(fileName);
+				hashedFile.setFileName(randomFileName.toString());
 				hashedFile.setSize(tmpFileLength);
 				fileSystemRepository.save(hashedFile);
 			} else {


### PR DESCRIPTION
Should be merged after PR #142 (contains commits of it)

the fix changes the upload functionality to only store the filename without the extension since the FileSystem itself is somehow messing with the ids.
