### PR TITLE
Remove Details Column in List CSAR Table. ..

### DIFF
--- a/src/main/webapp/listCsarServlet.ftl
+++ b/src/main/webapp/listCsarServlet.ftl
@@ -10,15 +10,13 @@
 	<thead>
 		<tr>
 			<th>CSAR Name</th>
-			<th>-</th>
 			<th>Delete</th>
 		</tr>
 	</thead>
 	<tbody>
 <#list csars as csar>
 	<tr>
-		<td>${csar.name}</td>
-		<td><a href="${basePath}/csar/${csar.id}">Details</a></td>
+		<td><a href="${basePath}/csar/${csar.id}">${csar.name}</a></td>
 		<td><a href="${basePath}/deletecsar/${csar.id}">Delete</a></td>
 	</tr>
 </#list>


### PR DESCRIPTION
I think its better, if you can click on the name of the CSAR to show its details and CSAR FILEs instead of a seperate column for Details-Links.