### PR TITLE
CreateCsarService.getResults returns id instead of boolean refs #149

### DIFF
--- a/src/main/java/org/opentosca/csarrepo/service/CreateCsarService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/CreateCsarService.java
@@ -12,6 +12,8 @@ import org.opentosca.csarrepo.model.repository.CsarRepository;
  */
 public class CreateCsarService extends AbstractService {
 
+	long csarId = -1;
+
 	private static final Logger LOGGER = LogManager.getLogger(CreateCsarService.class);
 
 	/**
@@ -26,16 +28,17 @@ public class CreateCsarService extends AbstractService {
 			Csar csar = new Csar();
 			csar.setName(name);
 			csarRepo.save(csar);
+			csarId = csar.getId();
 		} catch (PersistenceException e) {
 			this.addError(e.getMessage());
 			LOGGER.error(e);
 		}
 	}
 
-	public boolean getResult() {
+	public long getResult() {
 		super.logInvalidResultAccess("getResult");
 
-		return !this.hasErrors();
+		return csarId;
 	}
 
 }


### PR DESCRIPTION
Other files (especially the servlet) were not touched because getResults() is never invoked.
The servlet ensures everything went fine by invoking .hasErrors()