### PR TITLE
Rest download: changed MIME type of csarFiles

### DIFF
--- a/src/main/java/org/opentosca/csarrepo/rest/resource/CsarFileResource.java
+++ b/src/main/java/org/opentosca/csarrepo/rest/resource/CsarFileResource.java
@@ -77,7 +77,7 @@ public class CsarFileResource {
 	}
 
 	@GET
-	@Produces("application/csar")
+	@Produces("application/vnd.opentosca.csar+zip")
 	@Path("/download")
 	public Response getFile() {
 


### PR DESCRIPTION
New Mimetype: "application/vnd.opentosca.csar+zip"

... will be rebased after other pull requests