### PR TITLE
set dashboard as startpage inside web.xml refs #246

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -22,4 +22,7 @@
     <param-name>log4jConfiguration</param-name>
     <param-value>/WEB-INF/log4j2.xml</param-value>
   </context-param>
+  <welcome-file-list>
+  	<welcome-file>dashboard</welcome-file>
+  </welcome-file-list>
 </web-app>


### PR DESCRIPTION
the occuring bug was that http://.../csarrepo/ was not defined anymore as the root servlet was remapped to /dashboard.

Now /dashboard is the entry point of the web application (which gets redirected to /login if no usersession is present)