### PR TITLE
uploadService now also retrieves the plans (including references) from the serviceTemplate fixes #336

### DIFF
--- a/src/main/java/org/opentosca/csarrepo/model/Csar.java
+++ b/src/main/java/org/opentosca/csarrepo/model/Csar.java
@@ -1,14 +1,21 @@
 package org.opentosca.csarrepo.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.persistence.CascadeType;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.MapKey;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -54,6 +61,14 @@ public class Csar {
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "csarWineryServerId.csar")
 	@LazyCollection(LazyCollectionOption.FALSE)
 	private List<CsarWineryServer> csarWineryServer = new ArrayList<CsarWineryServer>();
+
+	@ElementCollection
+	@MapKeyColumn(name = "key_planID")
+	@Column(name = "value_zipFileName")
+	@CollectionTable(name = "csar_plans", joinColumns = @JoinColumn(name = "csar_id"))
+	@LazyCollection(LazyCollectionOption.FALSE)
+	// used to map the planID to the relating zip-filename
+	private Map<String, String> plans = new HashMap<String, String>();
 
 	public Csar() {
 	}
@@ -200,6 +215,25 @@ public class Csar {
 	 */
 	public void setCsarWineryServer(List<CsarWineryServer> csarWineryServer) {
 		this.csarWineryServer = csarWineryServer;
+	}
+
+	/**
+	 * Adds a reference entry for a plan (id to zipFileName)
+	 * 
+	 * @param planId
+	 * @param planReference
+	 */
+	public void addPlan(String planId, String planReference) {
+		this.plans.put(planId, planReference);
+	}
+
+	/**
+	 * returns the mappings from planID to planReference (ID -> zipFileName)
+	 * 
+	 * @return Map
+	 */
+	public Map<String, String> getPlanReferences() {
+		return this.plans;
 	}
 
 }

--- a/src/main/java/org/opentosca/csarrepo/model/Csar.java
+++ b/src/main/java/org/opentosca/csarrepo/model/Csar.java
@@ -14,7 +14,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.MapKey;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -63,8 +62,8 @@ public class Csar {
 	private List<CsarWineryServer> csarWineryServer = new ArrayList<CsarWineryServer>();
 
 	@ElementCollection
-	@MapKeyColumn(name = "key_planID")
-	@Column(name = "value_zipFileName")
+	@MapKeyColumn(name = "key_plan_id")
+	@Column(name = "value_zip_filename")
 	@CollectionTable(name = "csar_plans", joinColumns = @JoinColumn(name = "csar_id"))
 	@LazyCollection(LazyCollectionOption.FALSE)
 	// used to map the planID to the relating zip-filename

--- a/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
@@ -27,6 +27,7 @@ import org.opentosca.csarrepo.model.repository.CsarFileRepository;
 import org.opentosca.csarrepo.model.repository.CsarRepository;
 import org.opentosca.csarrepo.model.repository.FileSystemRepository;
 import org.opentosca.csarrepo.util.Extractor;
+import org.opentosca.csarrepo.util.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -131,9 +132,11 @@ public class UploadCsarFileService extends AbstractService {
 				Element item = (Element) nodeList.item(i);
 				String planId = item.getAttribute("id");
 				String fullZipPath = (String) referenceExpression.evaluate(item, XPathConstants.STRING);
-				//TODO: trim path away
-				String trimmedFileName = fullZipPath;
+				String trimmedFileName = StringUtils.extractFilenameFromPath(fullZipPath);
 				csar.addPlan(planId, trimmedFileName);
+				UploadCsarFileService.LOGGER.debug(
+						"Extracted plan id: '{}' reference: '{}' from csar->id: '{}', ns: '{}' / name: '{}'", planId,
+						trimmedFileName, csar.getId(), csar.getNamespace(), csar.getName());
 			}
 
 			String serviceTemplateId = serviceTemplate.getAttribute("id");

--- a/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
@@ -132,11 +132,12 @@ public class UploadCsarFileService extends AbstractService {
 				Element item = (Element) nodeList.item(i);
 				String planId = item.getAttribute("id");
 				String fullZipPath = (String) referenceExpression.evaluate(item, XPathConstants.STRING);
-				String trimmedFileName = StringUtils.extractFilenameFromPath(fullZipPath);
-				csar.addPlan(planId, trimmedFileName);
+				String extractedFileName = StringUtils.extractFilenameFromPath(fullZipPath);
+
+				csar.addPlan(planId, extractedFileName);
 				UploadCsarFileService.LOGGER.debug(
 						"Extracted plan id: '{}' reference: '{}' from csar->id: '{}', ns: '{}' / name: '{}'", planId,
-						trimmedFileName, csar.getId(), csar.getNamespace(), csar.getName());
+						extractedFileName, csar.getId(), csar.getNamespace(), csar.getName());
 			}
 
 			String serviceTemplateId = serviceTemplate.getAttribute("id");

--- a/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
+++ b/src/main/java/org/opentosca/csarrepo/service/UploadCsarFileService.java
@@ -5,8 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.UUID;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -30,6 +28,7 @@ import org.opentosca.csarrepo.model.repository.CsarRepository;
 import org.opentosca.csarrepo.model.repository.FileSystemRepository;
 import org.opentosca.csarrepo.util.Extractor;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -41,11 +40,18 @@ public class UploadCsarFileService extends AbstractService {
 
 	private static final String ENTRY_DEFINITION_PATTERN = "Entry-Definitions: ([\\S]+)\\n";
 	private static final String TOSCA_METADATA_FILEPATH = "TOSCA-Metadata/TOSCA.meta";
-	private static final String X_PATH_EXPRESSION = "//*[local-name()='ServiceTemplate']/@*[name()='id' or name()='targetNamespace']";
 
 	private static final Logger LOGGER = LogManager.getLogger(UploadCsarFileService.class);
+	private static final String XPATH_PLANS_FROM_SERVICETEMPLATE = "//*[local-name()='Plan']";
+	private static final String XPATH_PLANMODELREFERENCE_REFERENCE = "//*[local-name()='PlanModelReference']/@*[name()='reference']";
 
 	private CsarFile csarFile;
+
+	// TODO: check if this is the newest one, or remove namespace checking by
+	// replacing it with "*"
+	private final String SERVICETEMPLATE_NS = "http://docs.oasis-open.org/tosca/ns/2011/12";
+
+	private final String SERVICETEMPLATE_LOCALNAME = "ServiceTemplate";
 
 	/**
 	 * @param userId
@@ -104,18 +110,34 @@ public class UploadCsarFileService extends AbstractService {
 			String xmlData = Extractor.unzip(temporaryFile, entryDefinition);
 
 			DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+			documentBuilderFactory.setNamespaceAware(true);
 			DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 			Document document = documentBuilder.parse(new ByteArrayInputStream(xmlData.getBytes()));
-			XPath xpath = XPathFactory.newInstance().newXPath();
-			XPathExpression expression = xpath.compile(X_PATH_EXPRESSION);
-			NodeList nodeList = (NodeList) expression.evaluate(document, XPathConstants.NODESET);
 
-			Map<String, String> nodeMap = new HashMap<>();
-			for (int i = 0; i < nodeList.getLength(); i++) {
-				nodeMap.put(nodeList.item(i).getNodeName(), nodeList.item(i).getNodeValue());
+			NodeList elementsByTagNameNS = document.getElementsByTagNameNS(SERVICETEMPLATE_NS,
+					SERVICETEMPLATE_LOCALNAME);
+			Element serviceTemplate = (Element) elementsByTagNameNS.item(0);
+
+			if (null == serviceTemplate) {
+				throw new PersistenceException("Service Definition does not contain valid ServiceTemplate");
 			}
-			String serviceTemplateId = nodeMap.get("id");
-			String namespace = nodeMap.get("targetNamespace");
+
+			XPath xpath = XPathFactory.newInstance().newXPath();
+			XPathExpression expression = xpath.compile(XPATH_PLANS_FROM_SERVICETEMPLATE);
+			XPathExpression referenceExpression = xpath.compile(XPATH_PLANMODELREFERENCE_REFERENCE);
+			NodeList nodeList = (NodeList) expression.evaluate(serviceTemplate, XPathConstants.NODESET);
+
+			for (int i = 0; i < nodeList.getLength(); i++) {
+				Element item = (Element) nodeList.item(i);
+				String planId = item.getAttribute("id");
+				String fullZipPath = (String) referenceExpression.evaluate(item, XPathConstants.STRING);
+				//TODO: trim path away
+				String trimmedFileName = fullZipPath;
+				csar.addPlan(planId, trimmedFileName);
+			}
+
+			String serviceTemplateId = serviceTemplate.getAttribute("id");
+			String namespace = serviceTemplate.getAttribute("targetNamespace");
 
 			if (null == csar.getServiceTemplateId()) {
 				csar.setServiceTemplateId(serviceTemplateId);

--- a/src/main/java/org/opentosca/csarrepo/util/StringUtils.java
+++ b/src/main/java/org/opentosca/csarrepo/util/StringUtils.java
@@ -90,14 +90,23 @@ public class StringUtils {
 	}
 
 	/**
-	 * Extracts the Filename from the given fullPath
+	 * Extracts the Filename without file extension from the given fullPath
 	 * 
 	 * @param fullpath
 	 *            the full file path containing either / or \
 	 * @return the filename only (part after the last \ and /)
 	 */
 	public static String extractFilenameFromPath(String fullFilepath) {
-		return fullFilepath.substring(fullFilepath.lastIndexOf("/") + 1).substring(fullFilepath.lastIndexOf("\\") + 1);
+
+		String filenameWithExtension = fullFilepath.substring(fullFilepath.lastIndexOf("/") + 1).substring(
+				fullFilepath.lastIndexOf("\\") + 1);
+
+		int dotPosition = filenameWithExtension.lastIndexOf('.');
+		if (dotPosition >= 0) {
+			return filenameWithExtension.substring(0, dotPosition);
+		} else {
+			return filenameWithExtension;
+		}
 
 	}
 }

--- a/src/main/java/org/opentosca/csarrepo/util/StringUtils.java
+++ b/src/main/java/org/opentosca/csarrepo/util/StringUtils.java
@@ -89,4 +89,15 @@ public class StringUtils {
 		}
 	}
 
+	/**
+	 * Extracts the Filename from the given fullPath
+	 * 
+	 * @param fullpath
+	 *            the full file path containing either / or \
+	 * @return the filename only (part after the last \ and /)
+	 */
+	public static String extractFilenameFromPath(String fullFilepath) {
+		return fullFilepath.substring(fullFilepath.lastIndexOf("/") + 1).substring(fullFilepath.lastIndexOf("\\") + 1);
+
+	}
 }


### PR DESCRIPTION
This functionality will be needed to for the plan invocation invoke (i.e. generate the links for the invocation of)  the plans)

* Parsing was refactored in general
* References are stored inside the CSAR with own joinTable (mapping: planID -> planReference(=fileZipName)-
